### PR TITLE
Fix: Ensure packages/core is built before root bundle script

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "auth:docker": "gcloud auth configure-docker us-west1-docker.pkg.dev",
     "auth": "npm run auth:npm && npm run auth:docker",
     "prerelease:dev": "npm run prerelease:version --workspaces && npm run prerelease:deps --workspaces",
-    "bundle": "npm run generate && node esbuild.config.js && node scripts/copy_bundle_assets.js",
+    "bundle": "npm run generate && npm run build:packages && node esbuild.config.js && node scripts/copy_bundle_assets.js",
     "build:cli": "npm run build --workspace packages/cli",
     "build:core": "npm run build --workspace packages/core",
     "build:packages": "npm run build:core && npm run build:cli",


### PR DESCRIPTION
The root `bundle` script, triggered by `npm install` via the `prepare` script, was attempting to use `@google/gemini-cli-core` before it was built. This caused a resolution error because the `dist` directory and its contents (like `index.js`) were missing in `packages/core`.

This change modifies the root `bundle` script to execute `npm run build:packages` (which builds `core` then `cli`) before running `esbuild.config.js`. This ensures that `@google/gemini-cli-core` is compiled and its artifacts are available when the main bundling process needs them.

Note: This change reveals pre-existing TypeScript errors within `packages/core` that prevent its successful compilation. Those errors are separate from this build orchestration fix.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
