### PR TITLE
Fix: Update strip-json-comments to ESM compatible version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9568,6 +9568,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11171,7 +11172,7 @@
         "shell-quote": "^1.8.2",
         "string-width": "^7.1.0",
         "strip-ansi": "^7.1.0",
-        "strip-json-comments": "^3.1.1",
+        "strip-json-comments": "^5.0.1",
         "update-notifier": "^7.3.1",
         "yargs": "^17.7.2"
       },
@@ -11227,6 +11228,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "packages/cli/node_modules/strip-json-comments": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.2.tgz",
+      "integrity": "sha512-4X2FR3UwhNUE9G49aIsJW5hRRR3GXGTBTZRMfv568O60ojM8HcWjV/VxAxCDW3SUND33O6ZY66ZuRcdkj73q2g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/cli/node_modules/undici-types": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,7 +53,7 @@
     "shell-quote": "^1.8.2",
     "string-width": "^7.1.0",
     "strip-ansi": "^7.1.0",
-    "strip-json-comments": "^3.1.1",
+    "strip-json-comments": "^5.0.1",
     "update-notifier": "^7.3.1",
     "yargs": "^17.7.2"
   },


### PR DESCRIPTION
Updated strip-json-comments from 3.1.1 to 5.0.1 in packages/cli/package.json to resolve a "require is not defined" error.

The previous version was a CommonJS module, which caused issues when imported into the ESM-based CLI project. Version 5.0.1 is ESM compatible.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
