### PR TITLE
Fix: Use global fetch instead of explicit undici import

### DIFF
--- a/packages/core/src/services/llm/openrouter_llm_service.ts
+++ b/packages/core/src/services/llm/openrouter_llm_service.ts
@@ -12,7 +12,7 @@ import {
   ResponseMessageChunk,
   SendMessageParams,
 } from './llm_service.js';
-import { fetch, Agent, RequestInfo, RequestInit, Response } from 'undici';
+// Removed undici import, relying on global fetch
 import { Part, GenerateContentResponseUsageMetadata } from '@google/genai'; // Added GenerateContentResponseUsageMetadata
 import { streamToJson } from '../../utils/streamToJson.js'; // Utility to parse NDJSON stream
 import {
@@ -73,7 +73,7 @@ interface OpenRouterResponse {
  */
 export class OpenRouterLLMService implements LLMService {
   private apiKey: string;
-  private httpClient: Agent; // undici Agent for potential connection pooling, keep-alive
+  // private httpClient: Agent; // Removed undici Agent
 
   constructor(
     private readonly config: Config,
@@ -83,10 +83,10 @@ export class OpenRouterLLMService implements LLMService {
     if (!this.apiKey) {
       throw new Error('OpenRouter API key is not available.');
     }
-    this.httpClient = new Agent({
-      // TODO: Configure keep-alive, timeouts, etc. as needed
-      // connections: 10, // Example: Max 10 connections
-    });
+    // this.httpClient = new Agent({ // Removed httpClient initialization
+    //   // TODO: Configure keep-alive, timeouts, etc. as needed
+    //   // connections: 10, // Example: Max 10 connections
+    // });
   }
 
   private mapToOpenRouterMessages(message: string | Part | (string | Part)[]): { role: string; content: string }[] {
@@ -179,7 +179,7 @@ export class OpenRouterLLMService implements LLMService {
           // 'X-Title': YOUR_APP_NAME,
         },
         body: JSON.stringify(requestBody),
-        dispatcher: this.httpClient,
+        // dispatcher: this.httpClient, // Removed dispatcher
       });
 
       const durationMs = Date.now() - startTime;
@@ -245,7 +245,7 @@ export class OpenRouterLLMService implements LLMService {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify(requestBody),
-        dispatcher: this.httpClient,
+        // dispatcher: this.httpClient, // Removed dispatcher
       });
 
       if (!undiciResponse.ok) {


### PR DESCRIPTION
Removes the direct import and usage of 'undici' in `openrouter_llm_service.ts`. The code will now rely on the globally available `fetch` provided by Node.js v18+.

This aims to resolve the "require is not defined" error that likely occurred due to issues with how `undici` was being bundled or imported in an ES module environment, especially with the custom `require` shim in the esbuild banner.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
